### PR TITLE
Implement CRU-Less version of this script.

### DIFF
--- a/MonitorSwap-Dummy.ps1
+++ b/MonitorSwap-Dummy.ps1
@@ -1,52 +1,26 @@
-$primarySerial = "LGTV"
-$dummySerial = "DUMMY"
+﻿$primaryMonitorId = "MONITOR\GSMC0C8\{4d36e96e-e325-11ce-bfc1-08002be10318}\0009"
 # How many seconds to wait after a stream is suspended/terminated before swapping back.
 $gracePeroid = 30
 $configSaveLocation = $env:TEMP
 
+
 function OnStreamStart() {
-    if (PrimaryScreenIsActive) {
-        CaptureMonitorPositions
-    }
     Write-Output "Dummy plug activated"
-    & .\MultiMonitorTool.exe /SetPrimary /enable $dummySerial
-    DisableOtherDisplays
+    & .\MultiMonitorTool.exe /LoadConfig "dummy.cfg" 
 }
 
-function DisableOtherDisplays() {
-    & .\MultiMonitorTool.exe /SaveConfig "$configSaveLocation\monitorinfo.ini"
-    Start-Sleep -Seconds 1
-    $monitorConfigLines = (Get-Content -Path "$configSaveLocation\monitorinfo.ini" | Select-String "MonitorID=.*|SerialNumber=.*|Width.*|Height.*|DisplayFrequency.*")
-    for ($i = 0; $i -lt $monitorConfigLines.Count; $i++) {
-        $serial = ($monitorConfigLines[$i + 1] -split "=") | Select-Object -Last 1
-
-        if ($serial -ne $dummySerial) {
-            $width = ($monitorConfigLines[$i + 2] -split "=") | Select-Object -Last 1
-            $height = ($monitorConfigLines[$i + 3] -split "=") | Select-Object -Last 1
-            $refresh = ($monitorConfigLines[$i + 4] -split "=") | Select-Object -Last 1
-
-            # Let's just go ahead and disable every other display.
-            if ($height -ne 0 -and $width -ne 0 -and $refresh -ne 0) {
-                & .\MultiMonitorTool.exe /disable $serial
-             }
-        }
-        else {
-            # Its not necessary to check the next four lines because its not the monitor we want.
-            $i += 4
-        }
-    }
-}
 
 function PrimaryScreenIsActive() {
     # For some displays, the primary screen can't be set until it wakes up from sleep.
     # This will continually poll the configuration to make sure the display has been set.
 
-    & .\MultiMonitorTool.exe /SaveConfig "$configSaveLocation\monitorinfo.ini"
-    $monitorConfigLines = (Get-Content -Path "$configSaveLocation\monitorinfo.ini" | Select-String "MonitorID=.*|SerialNumber=.*|Width.*|Height.*|DisplayFrequency.*")
+    & .\MultiMonitorTool.exe /SaveConfig "$configSaveLocation\current_monitor_config.cfg"
+    Start-Sleep -Seconds 1
+    $monitorConfigLines = (Get-Content -Path "$configSaveLocation\current_monitor_config.cfg" | Select-String "MonitorID=.*|SerialNumber=.*|Width.*|Height.*|DisplayFrequency.*")
     for ($i = 0; $i -lt $monitorConfigLines.Count; $i++) {
-        $serial = ($monitorConfigLines[$i + 1] -split "=") | Select-Object -Last 1
+        $monitorId = ($monitorConfigLines[$i] -split "=") | Select-Object -Last 1
 
-        if ($serial -eq $primarySerial) {
+        if ($monitorId -eq $primaryMonitorId) {
             $width = ($monitorConfigLines[$i + 2] -split "=") | Select-Object -Last 1
             $height = ($monitorConfigLines[$i + 3] -split "=") | Select-Object -Last 1
             $refresh = ($monitorConfigLines[$i + 4] -split "=") | Select-Object -Last 1
@@ -63,24 +37,16 @@ function PrimaryScreenIsActive() {
     return $false
 }
 
-function RestoreMonitorPositions() {
-    # Disabling monitors causes the monitor positions to change, so let's just load what the user had originally.
-    & .\MultiMonitorTool.exe /LoadConfig "$configSaveLocation\monitor-config.cfg"
-}
-
-function CaptureMonitorPositions() {
-    # Export the users monitor configuration so it can be restored later.
-    & .\MultiMonitorTool.exe /SaveConfig "$configSaveLocation\monitor-config.cfg"
-}
-
 function SetPrimaryScreen() {
     Write-Host "Attempting to set primary screen"
     if (IsCurrentlyStreaming) {
         return "No Operating Necessary Because already streaming"
     }
-    ./MultiMonitorTool.exe /SetPrimary /enable $primarySerial
+
+    & .\MultiMonitorTool.exe /LoadConfig "primary.cfg"
+    
+
     Start-Sleep -Milliseconds 750
-    & .\MultiMonitorTool.exe  /disable $dummySerial
 }
 
 function OnStreamEnd() {
@@ -108,13 +74,10 @@ function OnStreamEnd() {
         catch {
             ## Do Nothing, because we're expecting it to fail in cases like when user has a TV as a primary display.
         }
-        finally {
-            Start-Sleep -Seconds 5
-        }
+        Start-Sleep -Seconds 5
     }
 
     Write-Host "Dummy Plug Deactivated, Restoring original monitor configuration!"
-    RestoreMonitorPositions
 
 
 }

--- a/Readme.txt
+++ b/Readme.txt
@@ -1,18 +1,39 @@
-Open up MultiMontitor tool and capture the Monitor ID of your primary display.
-With CRU, edit your displays (click edit button) and add a serial number if it is empty. 
-Make sure the box that states "Include if slot available" is checked.
+CAVEATS:
+    If you are using Windows 11, you need to set your default terminal to "Windows Console Host"
+    Windows Terminal is currently bugged and does not respect hiding powershell scripts.
 
-You may need to delete a detailed resolution, as it only contains 4 slots typically.
-You will know it is correct if you see the serial number grayed out under detailed resolutions.
+    Once installing this script, you cannot move this folder as it will break the automation.
+    If you need to move the folder, simply uninstall and install the script again.
 
+Requirements:
 
-Then edit the DummyPlug.ps1 script
+For GFE users:
+    None
 
-Change the value of $primarySerial to match you primary monitors serial.
-Change the value of $dummySerial to match you dummy plugs serial.
+For Sunshine Users
+    Host must be Windows
+    Sunshine must be installed a service (it does not work with the zip version of Sunshine)
+    Sunshine logging level must be set to Debug
+    Users must have read permissions to %WINDIR%/Temp/Sunshine.log (do not change other permissions, just make sure Users has atleast read permisisons)
 
-Once done, install the script.
+1. Open up MultiMonitorTool and click on File -> Save Monitors Configuration and save it in the current folder this script is located in with the name of primary.cfg
+2. Open up MultiMonitorTool and click on File -> Save Monitors Configuration and save it in the current folder this script is located in with the name of dummy.cfg
+3. Open up the dummy.cfg file and set every parameter related to montor position, refresh, etc to -
+example:
+        Name=\\.\DISPLAY1
+        MonitorID=MONITOR\GSMC0C8\{4d36e96e-e325-11ce-bfc1-08002be10318}\0009
+        SerialNumber=LGTV
+        BitsPerPixel=0
+        Width=0
+        Height=0
+        DisplayFlags=0
+        DisplayFrequency=0
+        DisplayOrientation=0
+        PositionX=0
 
-NOTE: Do not move this folder after installing script, otherwise it will break.
+In the example above, I set every value to 0 which lets the script know to turn it off.
+4. In the primary.cfg file, locate your primary MonitorId and copy and paste it to the primaryMonitorId variable in the MonitorSwap-Dummy.ps1 file
+    example: 
+        $primaryMonitorId = "MONITOR\GSMC0C8\{4d36e96e-e325-11ce-bfc1-08002be10318}\0009"
 
-If you need to move folder, simply install it again to resolve.
+5. Install the script by double clicking the Install Script.bat file.


### PR DESCRIPTION
After a few days of testing, I have found a method of automating the dummy displays by using a configuration export instead of relying on configuring serial numbers with CRU.