### PR TITLE
bugfix: resolution reversion

### DIFF
--- a/MonitorSwapper-Functions.ps1
+++ b/MonitorSwapper-Functions.ps1
@@ -133,16 +133,20 @@ function OnStreamEndAsJob() {
         $job = Create-Pipe -pipeName "OnStreamEnd" 
 
         while ($true) {
-            $maxTries = 50
+            $maxTries = 100
             $tries = 0
 
-            if ($job.State -eq "Completed" -or (OnStreamEnd)) {
+            if ($job.State -eq "Completed") {
                 break;
             }
 
             while (($tries -lt $maxTries) -and ($job.State -ne "Completed")) {
-                Start-Sleep -Milliseconds 100
+                Start-Sleep -Milliseconds 50
                 $tries++
+            }
+
+            if((OnStreamEnd)){
+                break;
             }
         } 
         # We no longer need to listen for the end command since we've already restored at this point.

--- a/MonitorSwapper.ps1
+++ b/MonitorSwapper.ps1
@@ -95,10 +95,10 @@ try {
             Write-Host "Request to terminate has been processed, script will now revert monitor configuration."
             $endJob = OnStreamEndAsJob
 
-            # Continually poll the job to write to log file once every 3 seconds
+            # Continually poll the job to write to log file once every 1 seconds
             while($endJob.State -ne "Completed"){
                 $endJob | Receive-Job
-                Start-Sleep -Milliseconds 10
+                Start-Sleep -Seconds 1
             }
             break;
         }

--- a/MonitorSwapper.ps1
+++ b/MonitorSwapper.ps1
@@ -10,10 +10,23 @@ if ($null -eq $async) {
     exit
 }
 
-Start-Transcript -Path .\log.txt
+
 . .\MonitorSwapper-Functions.ps1
 
-Send-PipeMessage -pipeName "OnStreamEnd" -Message "Terminate"
+if(Test-Path "\\.\pipe\MonitorSwapper"){
+    Write-Host "Existing session found"
+    # Script is already running, let's gracefully terminate it and launch it again.
+    Send-PipeMessage MonitorSwapper Terminate
+    Start-Sleep -Seconds 20
+}
+
+if(Test-Path "\\.\pipe\OnStreamEnd"){
+    Write-Host "Pending termination pipe found, closing it out"
+    Send-PipeMessage OnStreamEnd Terminate
+    Start-Sleep -Seconds 5
+}
+
+Start-Transcript -Path .\log.txt
 
 
 # There is no need to have more than one of these scripts running, so lets close out the previous one gracefully.

--- a/Readme.md
+++ b/Readme.md
@@ -4,9 +4,7 @@ This script automates the process of switching your primary monitor with a dummy
 This is useful for users of Sunshine (a screen sharing software) who experience issues with sharing their primary monitor.
 
 ## Caveats:
- - If using Windows 11, you'll need to set the default terminal to Windows Console Host as there is currently a bug in Windows Terminal that prevents hidden consoles from working properly.
-    * That can be changed at Settings > System > For Developers > Terminal [Let Windows decide] >> (change to) >> Terminal [Windows Console Host]
-    * On older versions of Windows 11 it can be found at: Settings > Privacy & security > Security > For developers > Terminal [Let Windows decide] >> (change to) >> Terminal [Windows Console Host]
+ - If using Windows 11, make sure to update to the latest security patches as it fixes a known bug that prevents the scripts terminal from being hidden.
  - The script will stop working if you move the folder, simply reinstall it to resolve that issue.
  - Due to Windows API restrictions, this script does not work on cold reboots (hard crashes or shutdowns of your computer).
     * If you're cold booting, simply sign into the computer using the "Desktop" app on Moonlight, then end the stream, then start it again. 

--- a/Readme.md
+++ b/Readme.md
@@ -4,7 +4,9 @@ This script automates the process of switching your primary monitor with a dummy
 This is useful for users of Sunshine (a screen sharing software) who experience issues with sharing their primary monitor.
 
 ## Caveats:
- - If using Windows 11, make sure to update to the latest security patches as it fixes a known bug that prevents the scripts terminal from being hidden.
+ - If using Windows 11, you'll need to set the default terminal to Windows Console Host as there is currently a bug in Windows Terminal that prevents hidden consoles from working properly.
+    * That can be changed at Settings > System > For Developers > Terminal [Let Windows decide] >> (change to) >> Terminal [Windows Console Host]
+    * On older versions of Windows 11 it can be found at: Settings > Privacy & security > Security > For developers > Terminal [Let Windows decide] >> (change to) >> Terminal [Windows Console Host]
  - The script will stop working if you move the folder, simply reinstall it to resolve that issue.
  - Due to Windows API restrictions, this script does not work on cold reboots (hard crashes or shutdowns of your computer).
     * If you're cold booting, simply sign into the computer using the "Desktop" app on Moonlight, then end the stream, then start it again. 

--- a/Readme.md
+++ b/Readme.md
@@ -103,6 +103,9 @@ If you encounter issues with the script, you can try the following:
 - You will have to do this workaround mentioned here: https://github.com/Nonary/MonitorSwapAutomation/issues/9 
   - There is currently a bug in the MultiMonitor tool in some scenarios with people who have dual screens. I do not have the source code for that tool, so it is impossible for me to fix directly, a workaround has to be done until resolved by Nirsoft. Please report your issue to [nirsofer@yahoo.com](mailto:nirsofer@yahoo.com) so he can gather more users and data to ultimately resolve this issue.
 
+#### Resolution Change when resuming or starting new stream
+- Double check and make sure you have put the correct "dummyMonitorId" in the settings.json file, that way the script doesn't attempt to restore monitor profiles that are already active.
+
 ### Recent Changes
 - Fixes a bug that prevented the script from restoring the display in some scenarios, if user left their Moonlight client at the host screen.
 - Fixed a bug that prevented the script from self-terminating itself after the user suspended the session longer than their defined grace period in the settings file.


### PR DESCRIPTION
Fixed a bug that caused the monitor swap to attempt to restore the primary monitor if users had started a stream again before returning to their PC. Adjusted the script to allow it close itself and start a new session.